### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/Week1/environment_ds4b_301p_dev.yml
+++ b/Week1/environment_ds4b_301p_dev.yml
@@ -526,7 +526,7 @@ dependencies:
       - pyarrow==17.0.0
       - pyasn1==0.5.1
       - pyasn1-modules==0.3.0
-      - pyautogen==0.4.1
+      - ag2==0.4.1
       - pycryptodome==3.21.0
       - pydantic==2.10.3
       - pydantic-core==2.27.1

--- a/Week2/environment_ds4b_301p_dev_matt.yml
+++ b/Week2/environment_ds4b_301p_dev_matt.yml
@@ -524,7 +524,7 @@ dependencies:
       - pyarrow==17.0.0
       - pyasn1==0.5.1
       - pyasn1-modules==0.3.0
-      - pyautogen==0.4.1
+      - ag2==0.4.1
       - pycryptodome==3.21.0
       - pydantic==2.10.3
       - pydantic-core==2.27.1

--- a/Week3/environment_ds4b_301p_dev_matt.yml
+++ b/Week3/environment_ds4b_301p_dev_matt.yml
@@ -525,7 +525,7 @@ dependencies:
       - pyarrow==17.0.0
       - pyasn1==0.5.1
       - pyasn1-modules==0.3.0
-      - pyautogen==0.4.1
+      - ag2==0.4.1
       - pycryptodome==3.21.0
       - pydantic==2.10.3
       - pydantic-core==2.27.1


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
